### PR TITLE
Use actual coordinates

### DIFF
--- a/src/example-map.json
+++ b/src/example-map.json
@@ -1,50 +1,470 @@
 {
-  "results": 4,
+  "results": 93,
   "data": [
     {
-      "package": "epidemics",
-      "logo": "https://epiverse-trace.github.io/epidemics/logo.svg",
-      "website": "https://epiverse-trace.github.io/epidemics",
-      "source": "https://github.com/epiverse-trace/epidemics",
-      "vignettes": [],
-      "coord1": 0.384,
-      "coord2": 0.684
+      "package": "denguedatahub",
+      "coord1": -0.9627,
+      "coord2": 1.4179
     },
     {
-      "package": "finalsize",
-      "logo": "https://epiverse-trace.github.io/finalsize/logo.svg",
-      "website": "https://epiverse-trace.github.io/finalsize",
-      "source": "https://github.com/epiverse-trace/finalsize",
-      "vignettes": [],
-      "coord1": -0.384,
-      "coord2": -0.684
+      "package": "AMR",
+      "coord1": -0.2246,
+      "coord2": 0.1461
     },
     {
-      "package": "cfr",
-      "logo": "https://epiverse-trace.github.io/cfr/logo.svg",
-      "website": "https://epiverse-trace.github.io/cfr",
-      "source": "https://github.com/epiverse-trace/cfr",
-      "vignettes": [],
-      "coord1": -0.384,
-      "coord2": 0.684
+      "package": "bets.covid19",
+      "coord1": 0.4361,
+      "coord2": -0.0893
     },
     {
-      "package": "epiparameter",
-      "logo": "https://epiverse-trace.github.io/epiparameter/logo.svg",
-      "website": "https://epiverse-trace.github.io/epiparameter",
-      "source": "https://github.com/epiverse-trace/epiparameter",
-      "vignettes": [],
-      "coord1": 0.384,
-      "coord2": -0.684
+      "package": "trendeval",
+      "coord1": 0.3663,
+      "coord2": -0.7944
+    },
+    {
+      "package": "pomp",
+      "coord1": 0.4524,
+      "coord2": -0.8908
+    },
+    {
+      "package": "covid19swiss",
+      "coord1": -0.0149,
+      "coord2": 0.5615
+    },
+    {
+      "package": "covid19br",
+      "coord1": -1.3725,
+      "coord2": 1.1764
+    },
+    {
+      "package": "epiDisplay",
+      "coord1": -0.0324,
+      "coord2": 0.1119
+    },
+    {
+      "package": "HIMA",
+      "coord1": -0.1401,
+      "coord2": -0.9539
+    },
+    {
+      "package": "cmprsk",
+      "coord1": 0.6552,
+      "coord2": -0.8935
+    },
+    {
+      "package": "EpiModel",
+      "coord1": 0.6995,
+      "coord2": -0.0818
+    },
+    {
+      "package": "corona",
+      "coord1": 0.6127,
+      "coord2": 0.7009
+    },
+    {
+      "package": "epitrix",
+      "coord1": -0.1159,
+      "coord2": -0.1891
+    },
+    {
+      "package": "outbreaker2",
+      "coord1": 0.2628,
+      "coord2": 0.0406
+    },
+    {
+      "package": "RSurveillance",
+      "coord1": -0.1279,
+      "coord2": -1.0177
+    },
+    {
+      "package": "popEpi",
+      "coord1": 0.432,
+      "coord2": -0.3846
+    },
+    {
+      "package": "epiR",
+      "coord1": -0.7604,
+      "coord2": -0.5386
+    },
+    {
+      "package": "COVID19",
+      "coord1": -0.5437,
+      "coord2": 0.9212
+    },
+    {
+      "package": "covid19sf",
+      "coord1": -0.5996,
+      "coord2": 0.7434
     },
     {
       "package": "linelist",
-      "logo": "https://epiverse-trace.github.io/linelist/logo.svg",
-      "website": "https://epiverse-trace.github.io/linelist",
-      "source": "https://github.com/epiverse-trace/linelist",
-      "vignettes": [],
-      "coord1": 0.584,
-      "coord2": -0.1324
+      "coord1": 0.3597,
+      "coord2": 0.213
+    },
+    {
+      "package": "nhanesA",
+      "coord1": -0.2526,
+      "coord2": 0.261
+    },
+    {
+      "package": "apisensr",
+      "coord1": 0.9637,
+      "coord2": 0.4728
+    },
+    {
+      "package": "episensr",
+      "coord1": -0.8244,
+      "coord2": -0.0924
+    },
+    {
+      "package": "covid19france",
+      "coord1": 2.5757,
+      "coord2": 1.1799
+    },
+    {
+      "package": "NADA",
+      "coord1": 0.0919,
+      "coord2": -0.123
+    },
+    {
+      "package": "Bernadette",
+      "coord1": -0.1515,
+      "coord2": 0.5741
+    },
+    {
+      "package": "cholera",
+      "coord1": 0.4358,
+      "coord2": 0.1155
+    },
+    {
+      "package": "earlyR",
+      "coord1": -0.5809,
+      "coord2": 0.3138
+    },
+    {
+      "package": "surveillance",
+      "coord1": 0.2953,
+      "coord2": -0.5838
+    },
+    {
+      "package": "dde",
+      "coord1": 0.1209,
+      "coord2": -0.3799
+    },
+    {
+      "package": "etm",
+      "coord1": 0.3169,
+      "coord2": -0.6291
+    },
+    {
+      "package": "covid19italy",
+      "coord1": -0.2991,
+      "coord2": 1.3167
+    },
+    {
+      "package": "CovidMutations",
+      "coord1": 0.092,
+      "coord2": 0.5881
+    },
+    {
+      "package": "epinet",
+      "coord1": -0.3718,
+      "coord2": -0.4851
+    },
+    {
+      "package": "epiflows",
+      "coord1": 0.2971,
+      "coord2": 0.1866
+    },
+    {
+      "package": "TransPhylo",
+      "coord1": 0.2639,
+      "coord2": -0.066
+    },
+    {
+      "package": "R0",
+      "coord1": 0.3943,
+      "coord2": -0.6234
+    },
+    {
+      "package": "EnvStats",
+      "coord1": -0.0194,
+      "coord2": -1.0234
+    },
+    {
+      "package": "covid19.analytics",
+      "coord1": 1.0065,
+      "coord2": 0.5064
+    },
+    {
+      "package": "coarseDataTools",
+      "coord1": -0.286,
+      "coord2": -0.325
+    },
+    {
+      "package": "malariaAtlas",
+      "coord1": 0.7702,
+      "coord2": 0.4454
+    },
+    {
+      "package": "cfr",
+      "coord1": -0.4962,
+      "coord2": 0.3496
+    },
+    {
+      "package": "mediation",
+      "coord1": -0.6186,
+      "coord2": -0.7635
+    },
+    {
+      "package": "inctools",
+      "coord1": -1.0038,
+      "coord2": -0.1444
+    },
+    {
+      "package": "EpiILM",
+      "coord1": -0.1637,
+      "coord2": -0.9646
+    },
+    {
+      "package": "coronavirus",
+      "coord1": 0.189,
+      "coord2": 0.7963
+    },
+    {
+      "package": "mma",
+      "coord1": -0.5611,
+      "coord2": -0.3152
+    },
+    {
+      "package": "finalsize",
+      "coord1": -0.6926,
+      "coord2": 0.3744
+    },
+    {
+      "package": "mstate",
+      "coord1": 0.1637,
+      "coord2": -0.3394
+    },
+    {
+      "package": "EpiSignalDetection",
+      "coord1": -0.332,
+      "coord2": 0.6106
+    },
+    {
+      "package": "deSolve",
+      "coord1": 0.2973,
+      "coord2": -1.0499
+    },
+    {
+      "package": "endtoend",
+      "coord1": -0.9073,
+      "coord2": -0.5396
+    },
+    {
+      "package": "powerSurvEpi",
+      "coord1": -0.3896,
+      "coord2": -1.3112
+    },
+    {
+      "package": "riskCommunicator",
+      "coord1": -0.6478,
+      "coord2": -0.285
+    },
+    {
+      "package": "EpiILMCT",
+      "coord1": 0.2771,
+      "coord2": -0.7582
+    },
+    {
+      "package": "Epi",
+      "coord1": 0.0416,
+      "coord2": -0.5884
+    },
+    {
+      "package": "EpiReport",
+      "coord1": -0.0736,
+      "coord2": 0.2745
+    },
+    {
+      "package": "incidence2",
+      "coord1": 0.6618,
+      "coord2": 0.1136
+    },
+    {
+      "package": "epitools",
+      "coord1": -0.4871,
+      "coord2": -0.3612
+    },
+    {
+      "package": "colmozzie",
+      "coord1": -1.4394,
+      "coord2": 0.4603
+    },
+    {
+      "package": "dbparser",
+      "coord1": 0.1096,
+      "coord2": 0.9207
+    },
+    {
+      "package": "SpatialEpi",
+      "coord1": -0.0895,
+      "coord2": -0.161
+    },
+    {
+      "package": "diyar",
+      "coord1": 0.5796,
+      "coord2": -0.1046
+    },
+    {
+      "package": "trending",
+      "coord1": -0.19,
+      "coord2": 0.1335
+    },
+    {
+      "package": "covid19us",
+      "coord1": 1.6811,
+      "coord2": 0.9185
+    },
+    {
+      "package": "EpiNow2",
+      "coord1": 0.4011,
+      "coord2": -0.0395
+    },
+    {
+      "package": "epicontacts",
+      "coord1": 0.1114,
+      "coord2": 0.2808
+    },
+    {
+      "package": "adegenet",
+      "coord1": 0.1543,
+      "coord2": -0.3409
+    },
+    {
+      "package": "DSAIDE",
+      "coord1": -0.3391,
+      "coord2": -0.2763
+    },
+    {
+      "package": "bkmr",
+      "coord1": 0.3898,
+      "coord2": -0.9773
+    },
+    {
+      "package": "tsiR",
+      "coord1": 1.1455,
+      "coord2": -0.231
+    },
+    {
+      "package": "incidence",
+      "coord1": 0.3466,
+      "coord2": 0.0518
+    },
+    {
+      "package": "EpiContactTrace",
+      "coord1": -0.2521,
+      "coord2": -0.2023
+    },
+    {
+      "package": "socialmixr",
+      "coord1": 0.6294,
+      "coord2": 0.5956
+    },
+    {
+      "package": "odin",
+      "coord1": 0.7926,
+      "coord2": -0.0362
+    },
+    {
+      "package": "memapp",
+      "coord1": -1.6194,
+      "coord2": 0.4485
+    },
+    {
+      "package": "covid19dbcand",
+      "coord1": -0.4481,
+      "coord2": 1.0715
+    },
+    {
+      "package": "EpiCurve",
+      "coord1": -0.9907,
+      "coord2": 0.6135
+    },
+    {
+      "package": "shinySIR",
+      "coord1": 1.0185,
+      "coord2": 0.2405
+    },
+    {
+      "package": "argo",
+      "coord1": 0.4049,
+      "coord2": 0.3623
+    },
+    {
+      "package": "nosoi",
+      "coord1": 0.183,
+      "coord2": 0.0053
+    },
+    {
+      "package": "epibasix",
+      "coord1": -1.1632,
+      "coord2": -1.1411
+    },
+    {
+      "package": "EpiEstim",
+      "coord1": -0.7044,
+      "coord2": 0.0288
+    },
+    {
+      "package": "nbTransmission",
+      "coord1": -0.3923,
+      "coord2": -0.5029
+    },
+    {
+      "package": "cleanepi",
+      "coord1": 0.8832,
+      "coord2": 0.0158
+    },
+    {
+      "package": "modelSSE",
+      "coord1": -0.1023,
+      "coord2": -1.1358
+    },
+    {
+      "package": "epimdr",
+      "coord1": -0.0041,
+      "coord2": 0.349
+    },
+    {
+      "package": "mem",
+      "coord1": 0.7677,
+      "coord2": -0.1945
+    },
+    {
+      "package": "contactdata",
+      "coord1": -0.1101,
+      "coord2": 0.535
+    },
+    {
+      "package": "epitweetr",
+      "coord1": 0.4506,
+      "coord2": 0.6006
+    },
+    {
+      "package": "outbreaks",
+      "coord1": -1.3453,
+      "coord2": 0.8672
+    },
+    {
+      "package": "o2geosocial",
+      "coord1": -0.8423,
+      "coord2": 0.1767
+    },
+    {
+      "package": "SimInf",
+      "coord1": 0.5055,
+      "coord2": -0.2589
     }
   ]
 }


### PR DESCRIPTION
Obtained by weighted median of the docs (w vignette = 10, w function = 1)

I had skipped the placeholders values (website, logo, source) for now. They depend on https://github.com/epiverse-connect/epiverse-search/issues/16. Is this ok?